### PR TITLE
adding deprecation notice to assessment workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> Any reference to assessment workflows will be obsolete.
+
 # serverless-workflows-config
 
 This repository is designed to offer a method for installing workflows through Helm charts.

--- a/docs/main/mta-v7.x/README.md
+++ b/docs/main/mta-v7.x/README.md
@@ -4,6 +4,9 @@ Mta
 
 A Helm chart for MTA serverless workflow
 
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> Any reference to assessment workflows will be obsolete.
 
 Migration Toolkit for Application Analysis (MTA) v7.x workflow evaluates applications to determine potential risks and the associated costs of containerizing the applications. It uses the [MTA v7.x Operator](https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/7.0/html/introduction_to_the_migration_toolkit_for_applications/index) to perform the analysis.
 At the end of a successful assessment workflow, a link to the report will be available in Backstage, under the notifications plugin.

--- a/docs/main/mtv-migration/README.md
+++ b/docs/main/mtv-migration/README.md
@@ -4,6 +4,9 @@ MTV Migration
 
 A Helm chart for the MTV Migration serverless workflow
 
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> Any reference to assessment workflows will be obsolete.
 
 # Helm chart Configuration
 

--- a/docs/main/mtv-plan/README.md
+++ b/docs/main/mtv-plan/README.md
@@ -4,6 +4,9 @@ MTV Plan
 
 A Helm chart for the MTV Plan serverless assessment workflow
 
+> **🚨 Deprecation Notice: 🚨**  
+> From Orchestrator release version 1.7, Workflow Types will be retired. All workflows will act as infrastructure workflows, and no workflow will act as an assesment workflow. <br>
+> Any reference to assessment workflows will be obsolete.
 
 # Helm chart Configuration
 


### PR DESCRIPTION
This PR is part of the deprecation of Assessment workflows in Orchestrator.
Specifically, related to this story: https://issues.redhat.com/browse/FLPATH-2328